### PR TITLE
improve meeting-query performance by using `UNION` statements

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,30 +39,33 @@ app.delete('/:id', async function (req, res) {
 	    ?containerId ext:editorDocumentStatus <http://mu.semte.ch/application/concepts/a1974d071e6a47b69b85313ebdcef9f7>.
 	  }
 	  WHERE {
-	    ${sparqlEscapeUri(meetingId)} ?meetingP ?meetingO.
-
-	    OPTIONAL{
-	      ${sparqlEscapeUri(meetingId)} besluit:behandelt ?apId.
+			{
+				${sparqlEscapeUri(meetingId)} ?meetingP ?meetingO.
+			}
+			UNION
+			{
+				${sparqlEscapeUri(meetingId)} ext:hasIntermission ?intermissionId.
+	      ?intermissionId ?intermissionP ?intermissionO.
+			}
+			UNION
+			{
+				${sparqlEscapeUri(meetingId)} besluit:behandelt ?apId.
 	      ?apId ?apP ?apO.
 	      ?behandelingId dct:subject ?apId.
-	      ?behandelingId ?behandelingP ?behandelingO.
-	    }
-	    OPTIONAL{
-	      ${sparqlEscapeUri(meetingId)} ext:hasIntermission ?intermissionId.
-	      ?intermissionId ?intermissionP ?intermissionO.
-	    }
-	    OPTIONAL{
-	      ${sparqlEscapeUri(meetingId)} besluit:behandelt ?apId1.
-	      ?behandelingId1 dct:subject ?apId1.
-	      ?behandelingId1 ext:hasDocumentContainer ?containerId.
-	      ?containerId ext:editorDocumentStatus ?statusId.
-	    }
-	    OPTIONAL{
-	      ${sparqlEscapeUri(meetingId)} besluit:behandelt ?apId2.
-	      ?behandelingId2 dct:subject ?apId2.
-	      ?behandelingId2 besluit:heeftStemming ?voteId.
-	      ?voteId ?voteP ?voteO.
-	    }
+				{
+					?behandelingId ?behandelingP ?behandelingO.
+				}
+				UNION
+				{
+					?behandelingId ext:hasDocumentContainer ?containerId.
+					?containerId ext:editorDocumentStatus ?statusId.
+				}
+				UNION
+				{
+					?behandelingId besluit:heeftStemming ?voteId.
+	      	?voteId ?voteP ?voteO.
+				}
+			}
 	  }
 	`;
 	try {


### PR DESCRIPTION
### Overview
This PR improves the performance of deleting meetings by using `UNION` statements.

##### connected issues and PRs:
Discovered while working on [GN-5627](https://binnenland.atlassian.net/browse/GN-5627)


### Setup
Include this service in your local GN stack:
```yml
meeting:
    image: !reset null
    build: https://github.com/lblod/meeting-service.git#improve-delete-query-performance
```

### How to test/reproduce
- Start the GN app
- Open a meeting
- Delete it
- Ensure the meeting and all its agendapoints, intermissions etc. have been removed
- The new query should be quite a bit more performant

### Challenges/uncertainties
The query might be less intuitive (using the `UNION` statements instead of `OPTIONAL` statements), but it should be quite a bit more performant.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] no new deprecations
